### PR TITLE
Fix AggregateResolver values override

### DIFF
--- a/src/OcraCachedViewResolver/Compiler/TemplateMapCompiler.php
+++ b/src/OcraCachedViewResolver/Compiler/TemplateMapCompiler.php
@@ -75,7 +75,7 @@ class TemplateMapCompiler
 
         /* @var $queuedResolver ResolverInterface */
         foreach ($resolver->getIterator()->toArray() as $queuedResolver) {
-            $map = ArrayUtils::merge($map, $this->compileMap($queuedResolver));
+            $map = ArrayUtils::merge($this->compileMap($queuedResolver), $map);
         }
 
         return $map;

--- a/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
+++ b/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
@@ -172,10 +172,10 @@ class TemplateMapCompilerTest extends PHPUnit_Framework_TestCase
         $map = $this->compiler->compileMap($aggregateResolver);
 
         $this->assertCount(5, $map);
-        $this->assertSame('override-a-value', $map['a']);
+        $this->assertSame('a-value', $map['a']);
         $this->assertSame('b-value', $map['b']);
         $this->assertSame('c-value', $map['c']);
-        $this->assertSame('override-d-value', $map['d']);
+        $this->assertSame('d-value', $map['d']);
         $this->assertSame('e-value', $map['e']);
     }
 }


### PR DESCRIPTION
The `AggregateResolver` doesn't override values and the first match is returned.
So the `TemplateMapCompiler` should not override values.

This allows to override module templates with the application `template_map` configuration.