### PR TITLE
Fix AggregateResolver values override

### DIFF
--- a/src/OcraCachedViewResolver/Compiler/TemplateMapCompiler.php
+++ b/src/OcraCachedViewResolver/Compiler/TemplateMapCompiler.php
@@ -75,7 +75,7 @@ class TemplateMapCompiler
 
         /* @var $queuedResolver ResolverInterface */
         foreach ($resolver->getIterator()->toArray() as $queuedResolver) {
-            $map = ArrayUtils::merge($map, $this->compileMap($queuedResolver));
+            $map = ArrayUtils::merge($this->compileMap($queuedResolver), $map);
         }
 
         return $map;

--- a/src/OcraCachedViewResolver/Compiler/TemplateMapCompiler.php
+++ b/src/OcraCachedViewResolver/Compiler/TemplateMapCompiler.php
@@ -74,8 +74,8 @@ class TemplateMapCompiler
         $map = [];
 
         /* @var $queuedResolver ResolverInterface */
-        foreach (array_reverse($resolver->getIterator()->toArray()) as $queuedResolver) {
-            $map = ArrayUtils::merge($map, $this->compileMap($queuedResolver));
+        foreach ($resolver->getIterator() as $queuedResolver) {
+            $map = ArrayUtils::merge($this->compileMap($queuedResolver), $map);
         }
 
         return $map;

--- a/src/OcraCachedViewResolver/Compiler/TemplateMapCompiler.php
+++ b/src/OcraCachedViewResolver/Compiler/TemplateMapCompiler.php
@@ -74,8 +74,8 @@ class TemplateMapCompiler
         $map = [];
 
         /* @var $queuedResolver ResolverInterface */
-        foreach ($resolver->getIterator()->toArray() as $queuedResolver) {
-            $map = ArrayUtils::merge($this->compileMap($queuedResolver), $map);
+        foreach (array_reverse($resolver->getIterator()->toArray()) as $queuedResolver) {
+            $map = ArrayUtils::merge($map, $this->compileMap($queuedResolver));
         }
 
         return $map;

--- a/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
+++ b/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
@@ -172,10 +172,10 @@ class TemplateMapCompilerTest extends PHPUnit_Framework_TestCase
         $map = $this->compiler->compileMap($aggregateResolver);
 
         $this->assertCount(5, $map);
-        $this->assertSame('a-value', $map['a']);
+        $this->assertSame('a-value', $map['a']); // should not be overridden
         $this->assertSame('b-value', $map['b']);
         $this->assertSame('c-value', $map['c']);
-        $this->assertSame('d-value', $map['d']);
+        $this->assertSame('d-value', $map['d']); // should not be overridden
         $this->assertSame('e-value', $map['e']);
     }
 }

--- a/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
+++ b/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
@@ -172,10 +172,10 @@ class TemplateMapCompilerTest extends PHPUnit_Framework_TestCase
         $map = $this->compiler->compileMap($aggregateResolver);
 
         $this->assertCount(5, $map);
-        $this->assertSame('override-a-value', $map['a']);
+        $this->assertSame('a-value', $map['a']);
         $this->assertSame('b-value', $map['b']);
         $this->assertSame('c-value', $map['c']);
-        $this->assertSame('override-d-value', $map['d']);
+        $this->assertSame('d-value', $map['d']);
         $this->assertSame('e-value', $map['e']);
     }
 }

--- a/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
+++ b/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
@@ -159,15 +159,10 @@ class TemplateMapCompilerTest extends PHPUnit_Framework_TestCase
             ->method('getMap')
             ->will($this->returnValue(['a' => 'override-a-value', 'd' => 'override-d-value', 'e' => 'e-value']));
 
-        $iterator = $this->getMock(PriorityQueue::class);
-        $iterator
-            ->expects($this->any())
-            ->method('toArray')
-            ->will($this->returnValue([$mapResolver1, $mapResolver2, $mapResolver3]));
         $aggregateResolver
             ->expects($this->any())
             ->method('getIterator')
-            ->will($this->returnValue($iterator));
+            ->will($this->returnValue([$mapResolver1, $mapResolver2, $mapResolver3]));
 
         $map = $this->compiler->compileMap($aggregateResolver);
 

--- a/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
+++ b/tests/OcraCachedViewResolverTest/Compiler/TemplateMapCompilerTest.php
@@ -18,9 +18,9 @@
 
 namespace OcraCachedViewResolverTest\Compiler;
 
+use ArrayIterator;
 use PHPUnit_Framework_TestCase;
 use OcraCachedViewResolver\Compiler\TemplateMapCompiler;
-use Zend\Stdlib\PriorityQueue;
 use Zend\Stdlib\SplStack;
 use Zend\View\Resolver\AggregateResolver;
 use Zend\View\Resolver\ResolverInterface;
@@ -159,10 +159,11 @@ class TemplateMapCompilerTest extends PHPUnit_Framework_TestCase
             ->method('getMap')
             ->will($this->returnValue(['a' => 'override-a-value', 'd' => 'override-d-value', 'e' => 'e-value']));
 
+        $iterator = new ArrayIterator([$mapResolver1, $mapResolver2, $mapResolver3]);
         $aggregateResolver
             ->expects($this->any())
             ->method('getIterator')
-            ->will($this->returnValue([$mapResolver1, $mapResolver2, $mapResolver3]));
+            ->will($this->returnValue($iterator));
 
         $map = $this->compiler->compileMap($aggregateResolver);
 


### PR DESCRIPTION
The `AggregateResolver` doesn't override values and the first match is returned.
So the `TemplateMapCompiler` should not override values.

This allows to override module templates with the application `template_map` configuration.