### PR TITLE
Removed zend-config requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "require-dev": {
         "phpunit/phpunit":             "^5.4.2",
-        "squizlabs/php_codesniffer":   "~2.6.1"
+        "squizlabs/php_codesniffer":   "~2.6.1",
+        "zendframework/zend-config": "^2.6 || ^3.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "zendframework/zend-servicemanager": "^3.1.0",
         "zendframework/zend-mvc": "^3.0",
         "zendframework/zend-view": "^2.7",
-        "zendframework/zend-cache": "^2.7.1",
-        "zendframework/zend-config": "^2.6"
+        "zendframework/zend-cache": "^2.7.1"
     },
     "require-dev": {
         "phpunit/phpunit":             "^5.4.2",


### PR DESCRIPTION
I wanted to update requirements to allow zend-config v3, but then I saw that zend-config is not really required in this library.

IMHO, this library retrieves the array configuration from the container, so zend-mvc is enough as requirement. 

- Removed zend-config requirement